### PR TITLE
Alias block with restrict

### DIFF
--- a/lib/acts_as_follower/follow_scopes.rb
+++ b/lib/acts_as_follower/follow_scopes.rb
@@ -36,10 +36,12 @@ module ActsAsFollower # :nodoc:
     def unblocked
       where(blocked: false)
     end
+    alias :unrestricted :unblocked
 
     # returns blocked Follow records.
     def blocked
       where(blocked: true)
     end
+    alias :restricted :blocked
   end
 end

--- a/lib/acts_as_follower/follow_scopes.rb
+++ b/lib/acts_as_follower/follow_scopes.rb
@@ -36,12 +36,12 @@ module ActsAsFollower # :nodoc:
     def unblocked
       where(blocked: false)
     end
-    alias :unrestricted :unblocked
+    alias unrestricted unblocked
 
     # returns blocked Follow records.
     def blocked
       where(blocked: true)
     end
-    alias :restricted :blocked
+    alias restricted blocked
   end
 end

--- a/lib/acts_as_follower/followable.rb
+++ b/lib/acts_as_follower/followable.rb
@@ -90,6 +90,12 @@ module ActsAsFollower # :nodoc:
         followings.unblocked.for_follower(follower).first.present?
       end
 
+      # Returns true if the current instance is blocked by the passed record
+      # Returns false if the current instance is not blocked by the passed record or no follow is found
+      def restricted_by?(follower)
+        followings.blocked.for_follower(follower).first.present?
+      end
+
       def block(follower)
         get_follow_for(follower) ? block_existing_follow(follower) : block_future_follow(follower)
       end

--- a/lib/acts_as_follower/followable.rb
+++ b/lib/acts_as_follower/followable.rb
@@ -58,7 +58,7 @@ module ActsAsFollower # :nodoc:
       def blocked_followers_count
         followings.blocked.count
       end
-      alias :restricted_followers_count :blocked_followers_count
+      alias restricted_followers_count blocked_followers_count
 
       # Returns the followings records scoped
       def followers_scoped
@@ -78,10 +78,10 @@ module ActsAsFollower # :nodoc:
       #   blocked_followers_scope.to_a.collect{|f| f.follower}
       # end
 
-      def restricts(options={})
+      def restricts(options = {})
         blocked_followers_scope = followers_scoped.blocked
         blocked_followers_scope = apply_options_to_scope(blocked_followers_scope, options)
-        blocked_followers_scope.to_a.collect{|f| f.follower}
+        blocked_followers_scope.to_a.collect(&:follower)
       end
 
       # Returns true if the current instance is followed by the passed record
@@ -99,12 +99,12 @@ module ActsAsFollower # :nodoc:
       def block(follower)
         get_follow_for(follower) ? block_existing_follow(follower) : block_future_follow(follower)
       end
-      alias :restrict :block
+      alias restrict block
 
       def unblock(follower)
         get_follow_for(follower).try(:delete)
       end
-      alias :unrestrict :unblock
+      alias unrestrict unblock
 
       def get_follow_for(follower)
         followings.for_follower(follower).first

--- a/lib/acts_as_follower/followable.rb
+++ b/lib/acts_as_follower/followable.rb
@@ -58,6 +58,7 @@ module ActsAsFollower # :nodoc:
       def blocked_followers_count
         followings.blocked.count
       end
+      alias :restricted_followers_count :blocked_followers_count
 
       # Returns the followings records scoped
       def followers_scoped
@@ -77,6 +78,12 @@ module ActsAsFollower # :nodoc:
       #   blocked_followers_scope.to_a.collect{|f| f.follower}
       # end
 
+      def restricts(options={})
+        blocked_followers_scope = followers_scoped.blocked
+        blocked_followers_scope = apply_options_to_scope(blocked_followers_scope, options)
+        blocked_followers_scope.to_a.collect{|f| f.follower}
+      end
+
       # Returns true if the current instance is followed by the passed record
       # Returns false if the current instance is blocked by the passed record or no follow is found
       def followed_by?(follower)
@@ -86,10 +93,12 @@ module ActsAsFollower # :nodoc:
       def block(follower)
         get_follow_for(follower) ? block_existing_follow(follower) : block_future_follow(follower)
       end
+      alias :restrict :block
 
       def unblock(follower)
         get_follow_for(follower).try(:delete)
       end
+      alias :unrestrict :unblock
 
       def get_follow_for(follower)
         followings.for_follower(follower).first

--- a/lib/acts_as_follower/version.rb
+++ b/lib/acts_as_follower/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActsAsFollower
-  VERSION = '0.2.1'
+  VERSION = '0.2.2'
 end

--- a/lib/generators/templates/model.rb
+++ b/lib/generators/templates/model.rb
@@ -11,4 +11,5 @@ class Follow < ActiveRecord::Base
   def block!
     update_attribute(:blocked, true)
   end
+  alias :restrict! :block!
 end

--- a/lib/generators/templates/model.rb
+++ b/lib/generators/templates/model.rb
@@ -11,5 +11,5 @@ class Follow < ActiveRecord::Base
   def block!
     update_attribute(:blocked, true)
   end
-  alias :restrict! :block!
+  alias restrict! block!
 end

--- a/test/acts_as_followable_test.rb
+++ b/test/acts_as_followable_test.rb
@@ -133,7 +133,7 @@ class ActsAsFollowableTest < ActiveSupport::TestCase
         @jon.restrict(@bob)
       end
 
-      should "accept AR options" do
+      should 'accept AR options' do
         assert_equal 1, @jon.restricts(limit: 1).count
       end
     end
@@ -213,7 +213,7 @@ class ActsAsFollowableTest < ActiveSupport::TestCase
           assert_equal [], @jon.followers
         end
 
-        should "be in the list of blocks" do
+        should 'be in the list of blocks' do
           assert_equal [@sam], @jon.restricts
         end
       end
@@ -236,12 +236,11 @@ class ActsAsFollowableTest < ActiveSupport::TestCase
           assert_equal [], @sam.followers
         end
 
-        should "be in the list of restricts" do
+        should 'be in the list of restricts' do
           assert_equal [@jon], @sam.restricts
         end
       end
     end
-
 
     context 'unblocking a blocked follow' do
       setup do

--- a/test/acts_as_followable_test.rb
+++ b/test/acts_as_followable_test.rb
@@ -12,6 +12,7 @@ class ActsAsFollowableTest < ActiveSupport::TestCase
       assert @sam.respond_to?(:followers_count)
       assert @sam.respond_to?(:followers)
       assert @sam.respond_to?(:followed_by?)
+      assert @sam.respond_to?(:restricted_by?)
     end
   end
 
@@ -75,6 +76,17 @@ class ActsAsFollowableTest < ActiveSupport::TestCase
       should 'return_follower_status' do
         assert_equal true, @jon.followed_by?(@sam)
         assert_equal false, @sam.followed_by?(@jon)
+      end
+    end
+
+    context 'restricted_by' do
+      setup do
+        @jon.restrict(@sam)
+      end
+
+      should 'return_restricted_status' do
+        assert_equal true, @jon.restricted_by?(@sam)
+        assert_equal false, @sam.restricted_by?(@jon)
       end
     end
 

--- a/test/acts_as_followable_test.rb
+++ b/test/acts_as_followable_test.rb
@@ -114,6 +114,18 @@ class ActsAsFollowableTest < ActiveSupport::TestCase
       # end
     end
 
+    context 'restricts' do
+      setup do
+        @bob = FactoryBot.create(:bob)
+        @jon.restrict(@sam)
+        @jon.restrict(@bob)
+      end
+
+      should "accept AR options" do
+        assert_equal 1, @jon.restricts(limit: 1).count
+      end
+    end
+
     context 'blocking a follower' do
       context 'in my following list' do
         setup do
@@ -166,6 +178,59 @@ class ActsAsFollowableTest < ActiveSupport::TestCase
       end
     end
 
+    context 'restricting a follower' do
+      context 'in my following list' do
+        setup do
+          @jon.restrict(@sam)
+        end
+
+        should 'remove him from followers' do
+          assert_equal 0, @jon.followers_count
+        end
+
+        should 'add him to the blocked followers' do
+          assert_equal 1, @jon.restricted_followers_count
+        end
+
+        should 'not be able to follow again' do
+          @jon.follow(@sam)
+          assert_equal 0, @jon.followers_count
+        end
+
+        should 'not be present when listing followers' do
+          assert_equal [], @jon.followers
+        end
+
+        should "be in the list of blocks" do
+          assert_equal [@sam], @jon.restricts
+        end
+      end
+
+      context 'not in my following list' do
+        setup do
+          @sam.restrict(@jon)
+        end
+
+        should 'add him to the restricted followers' do
+          assert_equal 1, @sam.restricted_followers_count
+        end
+
+        should 'not be able to follow again' do
+          @sam.follow(@jon)
+          assert_equal 0, @sam.followers_count
+        end
+
+        should 'not be present when listing followers' do
+          assert_equal [], @sam.followers
+        end
+
+        should "be in the list of restricts" do
+          assert_equal [@jon], @sam.restricts
+        end
+      end
+    end
+
+
     context 'unblocking a blocked follow' do
       setup do
         @jon.block(@sam)
@@ -178,6 +243,22 @@ class ActsAsFollowableTest < ActiveSupport::TestCase
 
       should 'remove him from the blocked followers' do
         assert_equal 0, @jon.blocked_followers_count
+        # assert_equal [], @jon.blocks
+      end
+    end
+
+    context 'unrestricting a restricted follow' do
+      setup do
+        @jon.restrict(@sam)
+        @jon.unrestrict(@sam)
+      end
+
+      should 'not include the unblocked user in the list of followers' do
+        assert_equal [], @jon.followers
+      end
+
+      should 'remove him from the blocked followers' do
+        assert_equal 0, @jon.restricted_followers_count
         # assert_equal [], @jon.blocks
       end
     end
@@ -195,10 +276,21 @@ class ActsAsFollowableTest < ActiveSupport::TestCase
       should 'not be in the blocked followers count' do
         assert_equal 0, @jon.blocked_followers_count
       end
+    end
 
-      # should "not be in the blocks list" do
-      #   assert_equal [], @jon.blocks
-      # end
+    context 'unrestrict a non-existent follow' do
+      setup do
+        @sam.stop_following(@jon)
+        @jon.unrestrict(@sam)
+      end
+
+      should 'not be in the list of followers' do
+        assert_equal [], @jon.followers
+      end
+
+      should 'not be in the blocked followers count' do
+        assert_equal 0, @jon.restricted_followers_count
+      end
     end
 
     context 'followers_by_type' do

--- a/test/acts_as_follower_test.rb
+++ b/test/acts_as_follower_test.rb
@@ -112,7 +112,7 @@ class ActsAsFollowerTest < ActiveSupport::TestCase
           assert_equal 2, @sam.following_by_type_count('Band')
           assert_equal 1, @sam.following_by_type_count('User')
           assert_equal 0, @jon.following_by_type_count('Band')
-          @jon.block(@sam)
+          @jon.restrict(@sam)
           assert_equal 0, @sam.following_by_type_count('User')
         end
       end
@@ -202,9 +202,9 @@ class ActsAsFollowerTest < ActiveSupport::TestCase
       should_change('@sam.follow_count', by: -1) { @sam.follow_count }
     end
 
-    context 'blocked by followable' do
+    context 'restricted by followable' do
       setup do
-        @jon.block(@sam)
+        @jon.restrict(@sam)
         @user_follow = FactoryBot.create(:user)
       end
 
@@ -216,7 +216,7 @@ class ActsAsFollowerTest < ActiveSupport::TestCase
         assert_equal 1, @sam.follow_count
       end
 
-      should 'not return record of the blocked follows' do
+      should 'not return record of the restricted follows' do
         assert_equal 1, @sam.all_follows.size
         assert !@sam.all_follows.include?(@user_follow)
         assert !@sam.all_following.include?(@jon)


### PR DESCRIPTION
Using the word `restrict` now instead of `block`. 
Also adds `restricted_by?` method.